### PR TITLE
Modifies task creation to remove unnecessary timesteps.

### DIFF
--- a/seanode/models/stofs_2d_glo.py
+++ b/seanode/models/stofs_2d_glo.py
@@ -81,16 +81,15 @@ class STOFS2DGloTaskCreator(ModelTaskCreator):
             
             # Get date(s)
             if forecast_type == ForecastType.FORECAST:
-                # Just a single date for forecast, but make it into a list.
-                init_dates = [self.get_init_time_containing(version_start)]
-                time_slices = [None]
+                # Just a single date for forecast, but formed as a list.
+                init_dates, time_slices = self.get_init_time_forecast(
+                    version_start
+                )
             else:
                 # A list of dates for nowcast
-                init_dates = self.get_init_time_range(version_start, version_end)
-                time_slices = [
-                    (idt - datetime.timedelta(hours=self.nowcast_period), idt) 
-                    for idt in init_dates
-                ]
+                init_dates, time_slices = self.get_init_times_nowcast(
+                    version_start, version_end
+                )
         
             # Get FieldSources
             fs_list = []

--- a/test_setup.py
+++ b/test_setup.py
@@ -3,7 +3,7 @@ import pandas as pd
 from seanode.api import get_surge_model_at_stations
 
 
-df_out = get_surge_model_at_stations(
+df_forecast = get_surge_model_at_stations(
     'STOFS_2D_GLO',
     ['cwl_bias_corrected', 'u_vel', 'v_vel'],
     pd.Series(['8720218', '8720357', '8725114']),
@@ -15,4 +15,18 @@ df_out = get_surge_model_at_stations(
     'AWS'
 )
 
-print(df_out)
+print(df_forecast)
+
+df_nowcast = get_surge_model_at_stations(
+    'STOFS_2D_GLO',
+    ['cwl_bias_corrected'], 
+    pd.Series(['8720218', '8720357', '8725114']), 
+    datetime.datetime(2024,12,1,3,0),
+    datetime.datetime(2024,12,1,21,0),
+    'nowcast', 
+    'points', 
+    'MLLW', 
+    'AWS'
+)
+
+print(df_nowcast)


### PR DESCRIPTION
This PR changes the initialization time and associated time slice calculation in `seanode/models/model_task_creator.py`, and the use of these new functions in `seanode/models/stofs_2d_glo.py`.

The previous version returned excess time steps in nowcast retrieval, and returned the nowcast data as well as forecast data in forecast retrieval. 

See https://github.com/noaa-ocs-modeling/SurgeTeamCoordination/issues/803 and https://github.com/noaa-ocs-modeling/SurgeTeamCoordination/issues/833 

As well as removing unnecessary time steps from the output, this change can result in a slight speed-up by avoiding unnecessary file retrievals. 