### PR TITLE
Add metadata to output data frames.

### DIFF
--- a/seanode/analysis_task.py
+++ b/seanode/analysis_task.py
@@ -138,6 +138,23 @@ class AnalysisTask:
         
         # Subset stations. 
         df = extract_stations_by_nos_id(ds_sub.load(), self.stations)
+        
+        # Rename columns.
+        col_name_mapper = {vdict['varname_file']:vdict['varname_out'] 
+                           for vdict in self.varlist}
+        df = df.rename(columns=col_name_mapper)
+        
+        # Add metadata.
+        df.attrs['ColumnMetaData'] = {}
+        for vdict in self.varlist:
+            vmd = {}
+            if vdict['varname_file'] in ds_sub:
+                if ds_sub[vdict['varname_file']].attrs:
+                    vmd.update(ds_sub[vdict['varname_file']].attrs)
+            if 'datum' in vdict and vdict['datum'] is not None:
+                vmd['datum'] = vdict['datum']
+            df.attrs['ColumnMetaData'][vdict['varname_out']] = vmd
+        #
         return df
 
     def postprocess(self, output_datum: str) -> None:
@@ -159,11 +176,6 @@ class AnalysisTask:
         
         """
         logger.info('postprocessing data frame')
-        # Rename columns.
-        col_name_mapper = {vdict['varname_file']:vdict['varname_out'] 
-                           for vdict in self.varlist}
-        self.dataframe = self.dataframe.rename(columns=col_name_mapper)
-        
         # Datum conversion.
         if output_datum is not None:
             for vdict in self.varlist:
@@ -186,7 +198,15 @@ class AnalysisTask:
                                     + '"oceanmodeling/coops-metadata" repository.')
                         z_conv = numpy.where(numpy.isinf(z_conv), numpy.nan, z_conv)
                     self.dataframe[vdict['varname_out']] = z_conv
-        
+                    # Update metadata.
+                    try:
+                        self.dataframe.attrs['ColumnMetaData'][vdict['varname_out']]['datum'] = output_datum
+                    except KeyError:
+                        logger.warning(
+                            f'No metadata found for variable {vdict["varname_out"]} '
+                            + 'when updating datum after conversion.'
+                        )
+        #
         return
 
     def run(self, store: DataStore, output_datum: str) -> pandas.DataFrame:

--- a/seanode/analysis_task_grid.py
+++ b/seanode/analysis_task_grid.py
@@ -164,6 +164,22 @@ class GridAnalysisTask(AnalysisTask):
             method='nearest'
         ).to_dataframe().reset_index().set_index(['station','time'])
         
+        # Rename columns.
+        col_name_mapper = {vdict['varname_file']:vdict['varname_out'] 
+                           for vdict in self.varlist}
+        df = df.rename(columns=col_name_mapper)
+        
+        # Add metadata.
+        df.attrs['ColumnMetaData'] = {}
+        for vdict in self.varlist:
+            vmd = {}
+            if vdict['varname_file'] in ds_sub:
+                if ds_sub[vdict['varname_file']].attrs:
+                    vmd.update(ds_sub[vdict['varname_file']].attrs)
+            if 'datum' in vdict and vdict['datum'] is not None:
+                vmd['datum'] = vdict['datum']
+            df.attrs['ColumnMetaData'][vdict['varname_out']] = vmd
+        #
         return df
 
     

--- a/seanode/analysis_task_mesh.py
+++ b/seanode/analysis_task_mesh.py
@@ -206,6 +206,23 @@ class MeshAnalysisTask(AnalysisTask):
         logger.info('converting to data frame')
         df = ds_sub.to_dataframe().reset_index().set_index(['station','time'])
         
+        # Rename columns.
+        col_name_mapper = {vdict['varname_file']:vdict['varname_out'] 
+                           for vdict in self.varlist}
+        df = df.rename(columns=col_name_mapper)
+        
+        # Add metadata.
+        df.attrs['ColumnMetaData'] = {}
+        for vdict in self.varlist:
+            vmd = {}
+            if vdict['varname_file'] in ds_sub:
+                if ds_sub[vdict['varname_file']].attrs:
+                    vmd.update(ds_sub[vdict['varname_file']].attrs)
+            if 'datum' in vdict and vdict['datum'] is not None:
+                vmd['datum'] = vdict['datum']
+            df.attrs['ColumnMetaData'][vdict['varname_out']] = vmd
+        #
+        
         return df
 
 

--- a/seanode/request.py
+++ b/seanode/request.py
@@ -139,6 +139,21 @@ class SurgeModelRequest:
         else:
             logger.warning('No non-empty data frames returned from AnalysisTasks.')
             df_out = pandas.DataFrame()
+        # Add metadata.
+        df_out.attrs['DataFrameMetaData'] = {
+            'description':'seanode model data request',
+            'request_parameters': {
+                'model': self.model_name.value,
+                'data_store': self.data_store_name.value,
+                'variables': self.variables,
+                'number_of_stations': len(self.stations),
+                'forecast_type': self.forecast_type.value,
+                'geometry': self.geometry.value,
+                'start_date': self.start_date.isoformat(),
+                'end_date': self.end_date.isoformat(),
+                'output_datum': self.output_datum
+            }
+        }
         return df_out
 
     def _concat_and_update(
@@ -148,7 +163,8 @@ class SurgeModelRequest:
         """Combine a list of data frames into a single data frame.
 
         This function adds new columns and indices as needed, and populates
-        any NaN data where possible.
+        any NaN data where possible. It also combines metadata from the 
+        different input data frames.
 
         Parameters
         ----------
@@ -163,7 +179,10 @@ class SurgeModelRequest:
             Containing combined data of all data frames in the input. 
             
         """
-        result = df_list[0]
+        result = df_list[0].copy()
+        if 'ColumnMetaData' not in result.attrs:
+            result.attrs['ColumnMetaData'] = {}
+
         if len(df_list) > 1:
             for df in df_list[1:]:
                 
@@ -175,7 +194,22 @@ class SurgeModelRequest:
                     result = result.reindex(result.index.append(not_indexed))
                 if any(new_cols):
                     result[new_cols] = numpy.nan
-
+                    # Update metadata for new columns.
+                    for col in new_cols:
+                        result.attrs['ColumnMetaData'][col] = \
+                            df.attrs['ColumnMetaData'].get(col, {})
+                
+                # Check for any conflicting metadata.
+                for col in df.columns:
+                    if col in result.attrs['ColumnMetaData']:
+                        for key, val in df.attrs['ColumnMetaData'].get(col, {}).items():
+                            if key in result.attrs['ColumnMetaData'][col]:
+                                if result.attrs['ColumnMetaData'][col][key] != val:
+                                    logger.warning(
+                                        f'Conflicting metadata for column {col}, '
+                                        f'key {key}: "{result.attrs["ColumnMetaData"][col][key]}" vs. "{val}".'
+                                    )
+                
                 # Overwrite NaNs in output dataframe.
                 result.update(df, overwrite=False)
                 


### PR DESCRIPTION
Adds data frame and column-wise metadata to pandas data frame outputs. These are generated per analysis task, and then checked for consistency when combining analysis task output. Note that no attempt to merge conflicting metadata is performed.

All tests continued to pass, but note that the tests were not altered specifically to test the metadata output. Such tests might be added later once the metadata output format has been deemed appropriate for the STOFS event dashboard. 